### PR TITLE
feat: download and preview of certificate PDFs

### DIFF
--- a/app/cypress/e2e/CertificatePage.cy.ts
+++ b/app/cypress/e2e/CertificatePage.cy.ts
@@ -1,4 +1,5 @@
 import "cypress-localstorage-commands";
+import CertificateCard from "../../../app/src/components/Certificates/CertificateCard";
 
 const BACKEND_URL = Cypress.env('BACKEND_URL')
 const CERT_URL = Cypress.env('CERT_URL')
@@ -80,6 +81,51 @@ describe('Certificate overview page', () => {
 		cy.visit('http://localhost:3000/certificates')
 		cy.get('#certificate-list').should('exist')
 		cy.get('#card-0-title').should('have.text', 'Test Course')
+	});
+
+	it('Downloads/previews a certificate upon press of relevant button', () => {
+		cy.intercept('GET', `${CERT_URL}/api/creator-certificates/creator/*`, {
+			statusCode: 200,
+			body:
+				[
+					{
+						course: {
+							id: '1',
+							title: 'Test Course',
+							description: 'Test Description',
+							dateCreated: new Date(),
+							creator: 1,
+							sections: [],
+							thumbnail: '',
+							coverImage: '',
+							tags: [],
+							rating: 0,
+						},
+						creator: {
+							id: '1',
+							name: 'Test User',
+							email: '',
+						}
+					}
+				],
+		})
+		
+		cy.intercept('POST', `${CERT_URL}/api/student-certificates/download*`, {
+			statusCode: 200,
+			body: 'test',
+		
+		})
+
+		cy.visit('http://localhost:3000/certificates')
+		cy.window().then((win) => {
+			cy.stub(win, 'open').as('windowOpen')
+		});
+		cy.get('#dropdown-0').click();
+		cy.get('#download-button-0').click()
+		cy.get('@windowOpen').should('be.called')
+
+		cy.get('#preview-button-0').click()
+		cy.get('#preview-window-0').should('exist')
 	});
 })
 

--- a/app/src/components/Certificates/ActionButton.tsx
+++ b/app/src/components/Certificates/ActionButton.tsx
@@ -6,12 +6,13 @@ type propTypes = {
 	className?: string;
 	onClick?: () => void;
 	icon?: string;
+	id?: string;
 }
 
 export default function ActionButton(props: propTypes) {
 
 	return (
-		<button className="std-button rounded-lg px-7 cursor-pointer" onClick={props.onClick}>
+		<button id={props.id} className="std-button rounded-lg px-7 cursor-pointer" onClick={props.onClick}>
 			{props.children}
 			{props.icon ? <Icon path={props.icon} className='w-6 h-6 text-white float-right' /> : null}
 		</button>

--- a/app/src/components/Certificates/ActionButton.tsx
+++ b/app/src/components/Certificates/ActionButton.tsx
@@ -1,4 +1,5 @@
 import Icon from "@mdi/react";
+import { useState } from "react";
 
 type propTypes = {
 	children: React.ReactNode;
@@ -8,8 +9,9 @@ type propTypes = {
 }
 
 export default function ActionButton(props: propTypes) {
+
 	return (
-		<button className="std-button rounded-lg px-7 cursor-pointer">
+		<button className="std-button rounded-lg px-7 cursor-pointer" onClick={props.onClick}>
 			{props.children}
 			{props.icon ? <Icon path={props.icon} className='w-6 h-6 text-white float-right' /> : null}
 		</button>

--- a/app/src/components/Certificates/CertificateCard.tsx
+++ b/app/src/components/Certificates/CertificateCard.tsx
@@ -61,7 +61,7 @@ export default function CertificateCard(props: { certificate: Certificate, num: 
 							<p className="text-grayMedium hidden sm:inline-block ml-1">alunos</p>
 						</CertificateField>
 					</div>
-					<button onClick={toggleDropdown}>
+					<button id={"dropdown-" + props.num} onClick={toggleDropdown}>
 						<Icon path={mdiChevronDown} className='w-8 h-8 text-grayMedium hover:text-primary mr-5 float-right cursor-pointer' />
 					</button>
 					{isOpen && <div className="col-span-2 bg-grayLight h-[1px]"></div>}
@@ -70,16 +70,16 @@ export default function CertificateCard(props: { certificate: Certificate, num: 
 							{/** Export certificate */}
 							<p className="text-xl translate-y-2 text-grayDark">Exportar certificado: </p>
 							<div className="gap-20 flex flex-row-reverse ">
-								<ActionButton icon={mdiDownload} onClick={download}>
+								<ActionButton id={'download-button-' + props.num} icon={mdiDownload} onClick={download}>
 									<p>Baixar</p> {/** Download */}
 								</ActionButton>
-								<ActionButton icon={mdiFileEye} onClick={toggleModal}>
+								<ActionButton id={'preview-button-' + props.num} icon={mdiFileEye} onClick={toggleModal}>
 									<p> Previa </p> {/** Preview */}
 								</ActionButton>
 							</div>
 							{
 								previewVisible &&
-								<object className="rounded-xl justify-self-center col-span-2 mt-4" data={CERT_URL + pdfPath} type="application/pdf" width='600' height='482'/>
+								<object id={'preview-window-' + props.num} className="rounded-xl justify-self-center col-span-2 mt-4" data={CERT_URL + pdfPath} type="application/pdf" width='600' height='482'/>
 							}
 						</div>
 					}

--- a/app/src/components/Certificates/CertificateCard.tsx
+++ b/app/src/components/Certificates/CertificateCard.tsx
@@ -6,7 +6,8 @@ import categories from "../../helpers/courseCategories";
 import CertificateField from "./CertificateField";
 import { useEffect, useState } from "react";
 import ActionButton from "./ActionButton";
-
+import axios from "axios";
+import { CERT_URL } from "../../helpers/environment";
 
 
 export default function CertificateCard(props: { certificate: Certificate, num: number }) {
@@ -15,12 +16,28 @@ export default function CertificateCard(props: { certificate: Certificate, num: 
 	const maxTitleLength = 20;
 
 	const [isOpen, setIsOpen] = useState(false);
+	const [previewVisible, setPreviewVisible] = useState(false);
+	const [pdfPath, setPdfPath] = useState('');
+
+	function toggleModal() {
+		setPreviewVisible(!previewVisible);
+	}
 
 	function toggleDropdown() {
 		setIsOpen(!isOpen);
 	}
 
-	
+	useEffect(() => {
+		axios.post(CERT_URL + '/api/student-certificates/download?courseId=' + certificate.course._id + '&studentId=' + certificate.creator._id)
+			.then(res => {
+				setPdfPath(res.data);
+			});
+	}, [])
+
+	function download() {
+		console.log('download');
+		window.open(CERT_URL + pdfPath, '_blank');
+	}
 
 	return (
 		<div className="overflow-hidden w-full m-auto duration-200 shadow-md rounded-xl hover:shadow-lg group">
@@ -53,13 +70,17 @@ export default function CertificateCard(props: { certificate: Certificate, num: 
 							{/** Export certificate */}
 							<p className="text-xl translate-y-2 text-grayDark">Exportar certificado: </p>
 							<div className="gap-20 flex flex-row-reverse ">
-								<ActionButton icon={mdiDownload}>
+								<ActionButton icon={mdiDownload} onClick={download}>
 									<p>Baixar</p> {/** Download */}
 								</ActionButton>
-								<ActionButton icon={mdiFileEye}>
+								<ActionButton icon={mdiFileEye} onClick={toggleModal}>
 									<p> Previa </p> {/** Preview */}
 								</ActionButton>
 							</div>
+							{
+								previewVisible &&
+								<object className="rounded-xl justify-self-center col-span-2 mt-4" data={CERT_URL + pdfPath} type="application/pdf" width='600' height='482'/>
+							}
 						</div>
 					}
 

--- a/app/src/interfaces/Course.ts
+++ b/app/src/interfaces/Course.ts
@@ -26,6 +26,7 @@ export interface Course {
 }
 
 export interface contentCreator {
+	_id: string;
   firstName: string,
   lastName: string,
   email: string,

--- a/app/src/pages/Certificates.tsx
+++ b/app/src/pages/Certificates.tsx
@@ -5,8 +5,8 @@ import Layout from "../components/Layout";
 export default function Certificates() {
   return (
     <Layout meta="Certificates">
-      <div className='h-[93%] align-self-center lg:px-20 xl:px-40'>
-        <div className='m-8 p-8 pb-0 bg-white rounded-xl overflow-hidden min-h-full'>
+      <div className='h-[93%] relative align-self-center lg:px-20 xl:px-40'>
+        <div className='m-8 p-8 pb-0 bg-white rounded-xl h-full overflow-scroll'>
           <CertificateList />
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR adds the functionality for downloading/previewing certificate PDFs.

## Changes

- Added onClick to ActionButton for download and preview functions
- Added on click functions and a preview object element to certificate cards
- Added _id to contentCreator interface
- Fixed overflow behaviour for certificate list
- Added tests

## Related Issues

List any related issues or tickets that this pull request addresses or resolves.

## Checklist

- [x] Code has been tested locally and passes all relevant tests.
- [x] Documentation has been updated to reflect the changes, if applicable.
- [x] Code follows the established coding style and guidelines of the project.
- [x] All new and existing tests related to the changes have passed.
- [x] Any necessary dependencies or new packages have been properly documented.
- [x] Pull request title and description are clear and descriptive.
- [x] Reviewers have been assigned to the pull request.
- [x] Any potential security implications have been considered and addressed.
- [x] Performance impact of the changes has been evaluated, if relevant.

## Screenshots (if applicable)

<img width="1905" alt="image" src="https://github.com/Educado-App/educado-frontend/assets/92511194/afcc15bd-8c6e-4b4a-a95a-3225948def1a">

## If mobile/frontend pull request, what version of the backend is it stable, and running on? 

Branch: dev 

Commit: 39b3576

## Notes for Reviewers

Run the cert-test-pdf-download branch to test this. This branch is temporary and the same goes for the fact that requests are send to a `student-certificates` endpoint - this will be fixed as soon as the functionality has been fully implemented.