### PR TITLE
fix eslint configuration for ide and recommend extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "eslint.workingDirectories": [
+        "app"
+    ]
+}


### PR DESCRIPTION
As we already know the project has a linting issue and i think there are multiple reasons for this.

- There is no mention of ESLint in the setup/READMEs for any of the repos and most people dont that it is standard in javascript projects.
- The frontend repo is misconfigured so linting errors arent showing up while coding but only when the `linting` cli command is run.
This is caused because VS Code using the root directory as the _current working directory_ while the linting commands use the `app` directory as the current working directory.

There isnt a good reason this repo is using a subfolder as the working directory and not `root` as it isnt a monorepo. It is confusing to work with and makes the setup hard to work with. People have already installed new packages in the root of the project so now there are two `package.json`s: https://github.com/Educado-App/educado-frontend/commit/437e35f59b114dc6bebe2b036fab3e4bb9894c33#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

So we should do away with the `app` subfolder but there is currently a lot of outstanding work that havent been merged, and i dont want to be the guy that gives everybody a merge conflict.
This should be addressed pretty quickly so the amount of linting errors wont keep growing.

As a temporary solution this PR makes VS Code recommend installing ESLint and adds a workspace config (VS Code) so linting error now correctly show up during development (when the ESLint is installed)

**Can somebody verify that this works on their system?**

Before: 
![Screenshot 2024-10-17 173508](https://github.com/user-attachments/assets/53ec4922-7191-42d1-bc77-68e7d656086c)


After:
![Screenshot 2024-10-17 181017](https://github.com/user-attachments/assets/0d25211c-d02c-4b4a-a50d-c94a4f016258)
