### PR TITLE
Fix for issue #184

### DIFF
--- a/app/src/components/ApproveModal.tsx
+++ b/app/src/components/ApproveModal.tsx
@@ -9,17 +9,17 @@ interface ApproveModalProps {
   onClose: () => void;
   token: string
   userDetails: any;
-  applicationId: string;
+  userId: string;
   onHandleStatus: () => void;
 }
 
-const ApproveModal: React.FC<ApproveModalProps> = ({ isOpen, onClose, token, userDetails, applicationId, onHandleStatus }) => {
+const ApproveModal: React.FC<ApproveModalProps> = ({ isOpen, onClose, token, userDetails, userId, onHandleStatus }) => {
   if (!isOpen) return null;
 
   const handleAccept = async () => {
     try {
-      await AuthServices.AcceptApplication(applicationId);    // <- applicationId is actually baseUser!
-      AdminServices.changeUserRole(applicationId, token, 'creator');
+      await AuthServices.AcceptApplication(userId);
+      AdminServices.changeUserRole(userId, token, 'creator');
       onClose(); // Close the modal after rejection
       onHandleStatus();
       toast.success("Application approved!");

--- a/app/src/components/ApproveModal.tsx
+++ b/app/src/components/ApproveModal.tsx
@@ -18,7 +18,6 @@ const ApproveModal: React.FC<ApproveModalProps> = ({ isOpen, onClose, token, use
 
   const handleAccept = async () => {
     try {
-      console.log("applicationId: ", applicationId);
       await AuthServices.AcceptApplication(applicationId);    // <- applicationId is actually baseUser!
       AdminServices.changeUserRole(applicationId, token, 'creator');
       onClose(); // Close the modal after rejection

--- a/app/src/components/ApproveModal.tsx
+++ b/app/src/components/ApproveModal.tsx
@@ -18,7 +18,8 @@ const ApproveModal: React.FC<ApproveModalProps> = ({ isOpen, onClose, token, use
 
   const handleAccept = async () => {
     try {
-      await AuthServices.AcceptApplication(applicationId);
+      console.log("applicationId: ", applicationId);
+      await AuthServices.AcceptApplication(applicationId);    // <- applicationId is actually baseUser!
       AdminServices.changeUserRole(applicationId, token, 'creator');
       onClose(); // Close the modal after rejection
       onHandleStatus();

--- a/app/src/components/ProfileForms/PersonalInformation.tsx
+++ b/app/src/components/ProfileForms/PersonalInformation.tsx
@@ -194,7 +194,7 @@ export default function PersonalInformationForm({
           {/* Biograhy */}
           <div className="flex flex-col">
             <label htmlFor="bio" className="font-['Montserrat']">
-              Biografia e motivações:
+              Biografia
               <span className="p-2 text-[#FF4949] text-sm font-normal font-['Montserrat']">
                 *
               </span>

--- a/app/src/components/UserDetailsModal.tsx
+++ b/app/src/components/UserDetailsModal.tsx
@@ -205,7 +205,7 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({ isOpen, onClose, us
         </div>
       )}
       <RejectModal isOpen={isRejectModalOpen} onClose={closeRejectModal} userDetails={userDetails} applicationId={applicationId} onHandleStatus={onHandleStatus} />
-      <ApproveModal isOpen={isApproveModalOpen} onClose={closeApproveModal} token={token} userDetails={userDetails} applicationId={applicationId} onHandleStatus={onHandleStatus} />
+      <ApproveModal isOpen={isApproveModalOpen} onClose={closeApproveModal} token={token} userDetails={userDetails} userId={applicationId} onHandleStatus={onHandleStatus} />
     </>
   );
 };

--- a/app/src/utilities/dynamicForms.ts
+++ b/app/src/utilities/dynamicForms.ts
@@ -36,27 +36,36 @@ export default () => {
   userInfo.id ? id = userInfo.id : id = "id";
   const [userID] = useState(id);
 
+  // Get default values for empty forms
+  const { emptyAcademicObject: emptyEducationForm, emptyProfessionalObject: emptyWorkForm } = tempObjects();
+
   // Fetch data for academic and professional experience forms
   const fetchDynamicData = async () => {
     try {
-      const [educationResponse, workResponse] = await Promise.all([
+      const [educationFormResponse, workFormResponse] = await Promise.all([
         ProfileServices.getUserFormTwo(userID),
         ProfileServices.getUserFormThree(userID),
       ]);
      
       // Map backend variables to corresponding frontend variables  
-      const transformedEducationData = educationResponse.data.map((item: any) => ({
-        ...item,
-        educationStartDate: item.startDate,
-        educationEndDate: item.endDate,
-      }));
-  
+      const transformedEducationData = educationFormResponse.data.length > 0
+        ? educationFormResponse.data.map((item: any) => ({
+            ...item,
+            educationStartDate: item.startDate,
+            educationEndDate: item.endDate,
+          }))
+          // Set empty data if forms don't exist in database
+        : emptyEducationForm;
+    
       // Map backend variables to corresponding frontend variables
-      const transformedWorkData = workResponse.data.map((item: any) => ({
-        ...item,
-        workStartDate: item.startDate,
-        workEndDate: item.endDate,
-      }));
+      const transformedWorkData = workFormResponse.data.length > 0
+        ? workFormResponse.data.map((item: any) => ({
+            ...item,
+            workStartDate: item.startDate,
+            workEndDate: item.endDate,
+          }))
+          // Set empty data if forms don't exist in database
+        : emptyWorkForm;
 
       setEducationFormData(transformedEducationData);
       setExperienceFormData(transformedWorkData); 
@@ -66,6 +75,13 @@ export default () => {
     } 
     catch (error: any) {
       console.error("Error fetching dynamic data: ", error);
+      
+      // Handling error in e.g., database access (to avoid crashing page when forms are then expanded) 
+      setEducationFormData(emptyEducationForm);
+      setExperienceFormData(emptyWorkForm); 
+
+      setEducationErrors(emptyEducationForm.map(() => ({ educationStartDate: "", educationEndDate: "" })));
+      setExperienceErrors(emptyWorkForm.map(() => ({ workStartDate: "", workEndDate: "" })));
     }
   };
 


### PR DESCRIPTION
Issue
-
https://github.com/Educado-App/educado-frontend/issues/184
Profile page crashes when education or work experience forms are expanded. 
This happens when there are no profile forms stored in the database.

Branches
-
**Frontend**:
bug/profile-expanded-forms-crash

**Backend** (necessary):
bug/profile-forms-expanded-crash

Related PR
-
https://github.com/Educado-App/educado-backend/pull/189

Acceptance Criteria
-
- [x] Make profile page not crash even when no profile forms are stored in the database.
- [x] Ensure that all forms from the application is actually stored on the newly approved profile:
    - [x] Academic experience
    - [x] Professional experience

Images
-
![A](https://github.com/user-attachments/assets/2ff70822-25cf-4626-902f-f7242bb0d468)
![B](https://github.com/user-attachments/assets/b92220be-864b-432f-82db-378b3bcf1b90)
![C](https://github.com/user-attachments/assets/657dedfa-f8f0-4ba2-b8b1-cb236830841f)
![D](https://github.com/user-attachments/assets/6c674ee6-7fb0-4eda-8656-5c38fa24c779)
![E](https://github.com/user-attachments/assets/1c218dc9-55c4-4086-8ef4-72ccd80e5e6f)

Tests
-
- [x] Successful unit tests.
- [x] Functionality tested by another group member (Sigurd).
- [x] 10/10 CodeScene scores on relevant files.
- [x] No ESLint errors.