### PR TITLE
Module aliasing

### DIFF
--- a/app/src/pages/Courses.tsx
+++ b/app/src/pages/Courses.tsx
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 import { getUserToken } from "../helpers/userInfo";
 import CourseGuideButton from "../components/Courses/GuideToCreatingCourse";
 // Services
-import CourseServices from "../services/course.services";
+import CourseServices from  "@services/course.services";
 
 // Components
 import Layout from "../components/Layout";

--- a/app/src/services/certificate.services.ts
+++ b/app/src/services/certificate.services.ts
@@ -63,11 +63,11 @@ const deleteCertificate = async (creatorId: string, courseId: string) => {
 }
 
 // Export all methods
-const CourseServices = Object.freeze({
+const CertificateService = Object.freeze({
 	createCertificate,
 	getUserCertificates,
 	deleteCertificate,
 });
 
-export default CourseServices;
+export default CertificateService;
 

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -19,6 +19,18 @@
       "jest",
       "cypress"
     ],
+    "baseUrl": "./", 
+    "paths": {
+      "@assets/*": ["src/assets/*"],
+      "@components/*": ["src/components/*"],
+      "@contexts/*": ["src/contexts/*"],
+      "@helpers/*": ["src/helpers/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@interfaces/*": ["src/interfaces/*"],
+      "@pages/*": ["src/pages/*"],
+      "@services/*": ["src/services/*"],
+      "@utilities/*": ["src/utilities/*"]
+    }
   },
   "include": [
     "src",

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,5 +10,18 @@ export default defineConfig({
   plugins: [react()],
   define: {
     global: {}, // For working with AWS
+  },
+  resolve: {
+    alias: {
+      '@assets': path.resolve(__dirname, 'src/assets'),
+      '@components': path.resolve(__dirname, 'src/components'),
+      '@contexts': path.resolve(__dirname, 'src/contexts'),
+      '@helpers': path.resolve(__dirname, 'src/helpers'),
+      '@hooks': path.resolve(__dirname, 'src/hooks'),
+      '@interfaces': path.resolve(__dirname, 'src/interfaces'),
+      '@pages': path.resolve(__dirname, 'src/pages'),
+      '@services': path.resolve(__dirname, 'src/services'),
+      '@utilities': path.resolve(__dirname, 'src/utilities'),
+    },
   },
 });


### PR DESCRIPTION
## Description
Right now there is not aliasing set up for modules in the application so when importing stuff you have to use relative imports which in nested components can be quite ugly eg "import ExerciseService from '../../../services/exercise-services'", this also means that when moving a component you need to update all the imports which is frustrating

## Changes
Implemented module aliasing, meaning that you can now reference modules the same no matter the location your importing from eg "import ExerciseService from '@services/exercise-services' "

## Related Issues
https://github.com/Educado-App/educado-frontend/issues/195


## Additional Information 
I have not changed Imports in the components to utilize this new configuration but it is now configured with typescript and vite to allow to do so, which means after this is in dev people can slowly either update imports in their components to use the aliasing or start using it when making new imports 