### PR TITLE
lint disallow console log

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -16,7 +16,8 @@
               "allowString" : false,
               "allowNumber" : false
           }
-      ]
-  },
+        ],
+        "no-console": ["error", { "allow": ["error"] }]
+    },
   "ignorePatterns": ["__tests__/*", "cypress/*"]
 }


### PR DESCRIPTION
Disallow all `console` methods except `console.error`